### PR TITLE
Integrate Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+  
+script:
+  - javac *.java
+  - java FPTree data/sample.dat 2


### PR DESCRIPTION
PR #1 was blocked by some experimentation with CircleCI and the fact that the repo required mandatory review for all PRs before they could be merged. CircleCI is no longer integrated (although it was not actually required as a passing status check; it just gave failing indicators), and PR review is now optional.