### PR TITLE
Fixed null pointer exception

### DIFF
--- a/FPTree.java
+++ b/FPTree.java
@@ -250,7 +250,7 @@ public class FPTree {
      * we sort the items in descending order of frequencies
      * and create the FPTree header table.
      */
-    public void createFPTreeHeaderTable(Hashtable<String,Integer> items_frequency, Hashtable<PairElement, Integer> pairs_frequency)
+    public void createFPTreeHeaderTable(Hashtable<String,Integer> items_frequency)
     {
         Enumeration<String> e = items_frequency.keys();  //list of all items
         ArrayList<ItemElement> aie = new ArrayList<ItemElement>();  //placeholder to sort the frequent items
@@ -301,11 +301,14 @@ public class FPTree {
                     PairElement pair = new PairElement(curItem, flistItem);
                     Double lift = pairwiseLifts.get(pair);
                     if (lift == null) {
-                        pair.setFirst(flistItem, curItem);
+                        pair.setFirst(flistItem);
+                        pair.setSecond(curItem);
                         lift = pairwiseLifts.get(pair);
                     }
 
-                    totalLift += lift;
+                    if (lift != null) {
+                        totalLift += lift;
+                    }
                 }
 
                 if (maxTotalLift < totalLift) {
@@ -326,7 +329,7 @@ public class FPTree {
         }
     }
 
-    public static Hashtable<PairElement,Double> computePairwiseLifts(Hashtable<String, Integer> itemsFrequencyTable,
+    public Hashtable<PairElement,Double> computePairwiseLifts(Hashtable<String, Integer> itemsFrequencyTable,
                                                               Hashtable<PairElement, Integer> pairFrequencyTable,
                                                               PairElement highestPair) {
         Hashtable<PairElement, Double> pairwiseLifts = new Hashtable<>();
@@ -357,7 +360,7 @@ public class FPTree {
         return pairwiseLifts;
     }
 
-    public static void pruneInfrequentItems(Hashtable<String, Integer> itemsFrequencyTable) {
+    public void pruneInfrequentItems(Hashtable<String, Integer> itemsFrequencyTable) {
         for(Iterator<Map.Entry<String, Integer>> it = itemsFrequencyTable.entrySet().iterator(); it.hasNext();) {
             Map.Entry<String, Integer> entry = it.next();
             if (entry.getValue() < support_threshold) {
@@ -424,7 +427,7 @@ public class FPTree {
 
         setPairElementOrder(items_frequency, pairs_frequency);
 
-        createFPTreeHeaderTable(items_frequency, pairs_frequency);
+        createHeaderTable(items_frequency, pairs_frequency);
     }
 
     //overloaded method - file reading done between lines [start_at] and [end_at]
@@ -449,7 +452,7 @@ public class FPTree {
 
         setPairElementOrder(items_frequency, pairs_frequency);
 
-        createFPTreeHeaderTable(items_frequency, pairs_frequency);
+        createHeaderTable(items_frequency, pairs_frequency);
     }
     /*
      * second scan of transactions will create the FPTree and update the pointers in the FPTree header table.
@@ -506,7 +509,7 @@ public class FPTree {
                                           //conditional pattern base completely traversed
         setPairElementOrder(items_frequency, pairs_frequency);
 
-        createFPTreeHeaderTable(items_frequency, pairs_frequency);   //FPTree header table created
+        createHeaderTable(items_frequency, pairs_frequency);   //FPTree header table created
     }
 
     /* second scan of transactions entered as conditional pattern base

--- a/FPTree.java
+++ b/FPTree.java
@@ -277,11 +277,53 @@ public class FPTree {
         pruneInfrequentItems(itemsFrequencyTable);
 
         // Add the items in the highest pair to the f-list
-        ArrayList<ItemElement> flist = new ArrayList<>();
-        flist.add(highestPair.getFirst());
-        flist.add(highestPair.getSecond());
+        ArrayList<String> flist = new ArrayList<>();
+        String highestPairFirst = highestPair.getFirst();
+        String highestPairSecond = highestPair.getSecond();
+        flist.add(highestPairFirst);
+        flist.add(highestPairSecond);
 
+        // Remove items in highest pair from frequency table
+        itemsFrequencyTable.remove(highestPair.getFirst());
+        itemsFrequencyTable.remove(highestPair.getSecond());
 
+        while (!itemsFrequencyTable.isEmpty()) {
+            double maxTotalLift = Double.MIN_VALUE;
+            String maxTotalLiftItem = "";
+
+            for (Map.Entry<String, Integer> entry : itemsFrequencyTable.entrySet()) {
+                String curItem = entry.getKey();
+                // int curItemFrequency = curItem.getFrequency();
+                double totalLift = 0.0;
+
+                for (String flistItem : flist) {
+                    // int flistItemFrequency = flistItem.getFrequency();
+                    PairElement pair = new PairElement(curItem, flistItem);
+                    Double lift = pairwiseLifts.get(pair);
+                    if (lift == null) {
+                        pair.setFirst(flistItem, curItem);
+                        lift = pairwiseLifts.get(pair);
+                    }
+
+                    totalLift += lift;
+                }
+
+                if (maxTotalLift < totalLift) {
+                    maxTotalLift = totalLift;
+                    maxTotalLiftItem = curItem;
+                }
+            }
+
+            flist.add(maxTotalLiftItem);
+
+            // Remove the item just added to reduce search space for future iterations
+            itemsFrequencyTable.remove(maxTotalLiftItem);
+        }
+
+        int length = flist.size();
+        for (int i = 0; i < length; i++) {
+            header_table.add(new FPTreeHeaderElement(flist.get(i)));
+        }
     }
 
     public static Hashtable<PairElement,Double> computePairwiseLifts(Hashtable<String, Integer> itemsFrequencyTable,

--- a/FPTree.java
+++ b/FPTree.java
@@ -270,12 +270,15 @@ public class FPTree {
     }
 
     public void createHeaderTable(Hashtable<String,Integer> itemsFrequencyTable, Hashtable<PairElement,Integer> pairFrequencyTable) {
-        Hashtable<PairElement, Double> pairwiseLifts = computePairwiseLifts(itemsFrequencyTable, pairFrequencyTable);
+        PairElement highestPair = new PairElement();
+        Hashtable<PairElement, Double> pairwiseLifts = computePairwiseLifts(itemsFrequencyTable, pairFrequencyTable, highestPair);
     }
 
     public static Hashtable<PairElement,Double> computePairwiseLifts(Hashtable<String, Integer> itemsFrequencyTable,
-                                                              Hashtable<PairElement, Integer> pairFrequencyTable) {
+                                                              Hashtable<PairElement, Integer> pairFrequencyTable,
+                                                              PairElement highestPair) {
         Hashtable<PairElement, Double> pairwiseLifts = new Hashtable<>();
+        double maxLift = Double.MIN_VALUE;
 
         for (Map.Entry<PairElement, Integer> entry : pairFrequencyTable) {
             PairElement pair = entry.getKey();
@@ -287,6 +290,12 @@ public class FPTree {
             // TODO: Do we really need the * N?
             double lift = ((double) pairFrequency) / (firstFrequency * secondFrequency);
             pairwiseLifts.put(pair, lift);
+
+            if (maxLift < lift) {
+                maxLift = lift;
+                highestPair.setFirst(pair.getFirst());
+                highestPair.setSecond(pair.getSecond());
+            }
         }
 
         return pairwiseLifts;

--- a/FPTree.java
+++ b/FPTree.java
@@ -269,6 +269,29 @@ public class FPTree {
         } //FPTree header formed
     }
 
+    public void createHeaderTable(Hashtable<String,Integer> itemsFrequencyTable, Hashtable<PairElement,Integer> pairFrequencyTable) {
+        Hashtable<PairElement, Double> pairwiseLifts = computePairwiseLifts(itemsFrequencyTable, pairFrequencyTable);
+    }
+
+    public static Hashtable<PairElement,Double> computePairwiseLifts(Hashtable<String, Integer> itemsFrequencyTable,
+                                                              Hashtable<PairElement, Integer> pairFrequencyTable) {
+        Hashtable<PairElement, Double> pairwiseLifts = new Hashtable<>();
+
+        for (Map.Entry<PairElement, Integer> entry : pairFrequencyTable) {
+            PairElement pair = entry.getKey();
+            int pairFrequency = entry.getValue();
+
+            int firstFrequency = itemsFrequencyTable.get(pair.getFirst());
+            int secondFrequency = itemsFrequencyTable.get(pair.getSecond());
+
+            // TODO: Do we really need the * N?
+            double lift = ((double) pairFrequency) / (firstFrequency * secondFrequency);
+            pairwiseLifts.put(pair, lift);
+        }
+
+        return pairwiseLifts;
+    }
+
     /*
      * Following function inserts a prefix into prefix tree/FPTree with the corresponding count.
      */


### PR DESCRIPTION
Changed createHeaderTable implementation to not prune infrequent items, but instead add items already in flist to a hashset

Reverted a createHeaderTable call in version of firstScan with conditional pattern base parameter back to original call
